### PR TITLE
Expose more message handlers and drawing API

### DIFF
--- a/gdi.rs
+++ b/gdi.rs
@@ -11,7 +11,7 @@ use std::ptr;
 
 use libc::c_int;
 use ll::all::PAINTSTRUCT;
-use ll::types::{HDC, HWND, RECT, HBITMAP, HANDLE, BOOL, DWORD, LONG, BYTE, HGDIOBJ};
+use ll::types::{HDC, HWND, RECT, HBITMAP, HANDLE, BOOL, DWORD, LONG, BYTE, HGDIOBJ, COLORREF, HBRUSH};
 use ll::gdi;
 use font::Font;
 use window::WindowImpl;
@@ -50,6 +50,14 @@ impl Dc {
         }
     }
 
+    pub fn set_text_color(&self, color: COLORREF) -> COLORREF {
+        unsafe { gdi::SetTextColor(self.raw, color) }
+    }
+
+    pub fn set_background_color(&self, color: COLORREF) -> COLORREF {
+        unsafe { gdi::SetBkColor(self.raw, color) }
+    }
+
     pub fn create_compatible_bitmap(&self, width: int, height: int) -> Bitmap {
         let raw = unsafe {
             gdi::CreateCompatibleBitmap(self.raw, width as c_int, height as c_int)
@@ -68,6 +76,29 @@ impl Dc {
         };
         return res != 0;
     }
+
+    pub fn fill_rect(&self, left_top: (int, int), right_bottom: (int, int), brush: HBRUSH) -> bool {
+        let (left, top) = left_top;
+        let (right, bottom) = right_bottom;
+        let rect = RECT {
+            left: left as LONG, top: top as LONG,
+            right: right as LONG, bottom: bottom as LONG
+        };
+        let res = unsafe {
+            gdi::FillRect(self.raw, &rect, brush)
+        };
+        return res != 0;
+    }
+
+    pub fn rect(&self, left_top: (int, int), right_bottom: (int, int)) -> bool {
+        let (left, top) = left_top;
+        let (right, bottom) = right_bottom;
+        let res = unsafe {
+            gdi::Rectangle(self.raw, left as c_int, top as c_int, right as c_int, bottom as c_int)
+        };
+        return res != 0;
+    }
+
 }
 
 pub struct PaintDc {

--- a/ll/all.rs
+++ b/ll/all.rs
@@ -197,7 +197,11 @@ extern "system" {
         xDesired: c_int, yDesired: c_int, load: UINT
     ) -> HANDLE;
 
+    pub fn GetSysColor(nIndex: c_int) -> DWORD;
+
     pub fn GetClientRect(hwnd: HWND, rect: LPRECT) -> BOOL;
+
+    pub fn InvalidateRect(hwnd: HWND, lpRect: *const RECT, erase: BOOL) -> BOOL;
 
     pub fn SetWindowPos(
         hwnd: HWND, hwndInsertAfter: HWND, x: c_int, y: c_int,

--- a/ll/gdi.rs
+++ b/ll/gdi.rs
@@ -9,7 +9,7 @@
 
 use libc::c_int;
 use libc::types::os::arch::extra::{LPCWSTR, LPWSTR};
-use ll::types::{HDC, BOOL, HBITMAP, HGDIOBJ, DWORD, HFONT};
+use ll::types::{HDC, BOOL, HBITMAP, HGDIOBJ, DWORD, HFONT, COLORREF, RECT, HBRUSH};
 
 #[link(name = "gdi32")]
 extern "system" {
@@ -21,10 +21,18 @@ extern "system" {
 
     pub fn SelectObject(hdc: HDC, hgdiobj: HGDIOBJ) -> HGDIOBJ;
 
+    pub fn GetStockObject(fnObject: c_int) -> HGDIOBJ;
+
     pub fn DeleteObject(hObject: HGDIOBJ) -> BOOL;
+
+    pub fn SetDCBrushColor(hdc: HDC, crColor: COLORREF) -> COLORREF;
 
     pub fn BitBlt(hdcDest: HDC, nXDest: c_int, nYDest: c_int, nWidth: c_int, nHeight: c_int,
                   hdcSrc: HDC, nXSrc: c_int, nYSrc: c_int, dwRop: DWORD) -> BOOL;
+
+    pub fn FillRect(hDC: HDC, lprc: *const RECT, hbr: HBRUSH) -> c_int;
+
+    pub fn Rectangle(hDC: HDC, nLeftRect: c_int, nTopRect: c_int, nRightRect: c_int, nBottomRect: c_int) -> BOOL;
 
     pub fn CreateFontW(
         height: c_int, width: c_int, escapement: c_int, orientation: c_int,
@@ -36,4 +44,8 @@ extern "system" {
     pub fn TextOutW(
         hdc: HDC, nXStart: c_int, nYStart: c_int, lpString: LPWSTR, cchString: c_int
     ) -> BOOL;
+
+    pub fn SetTextColor(hdc: HDC, color: COLORREF) -> COLORREF;
+
+    pub fn SetBkColor(hdc: HDC, color: COLORREF) -> COLORREF;
 }

--- a/macros.rs
+++ b/macros.rs
@@ -54,6 +54,47 @@ macro_rules! wnd_proc_thunk(
             return 0 as ::windows::ll::types::LRESULT;
         }
     );
+    ($self_:ident, $msg:ident, $w:ident, $l:ident, WM_LBUTTONDOWN) => (
+        if $msg == 0x0201 { // WM_LBUTTONDOWN
+            let l = $l as u32;
+            let x = (l & 0xFFFF) as int;
+            let y = (l >> 16) as int;
+            let flags = $w as u32;
+            $self_.on_left_button_down(x, y, flags);
+            return 0 as ::windows::ll::types::LRESULT;
+        }
+    );
+    ($self_:ident, $msg:ident, $w:ident, $l:ident, WM_LBUTTONUP) => (
+        if $msg == 0x0202 { // WM_LBUTTONUP
+            let l = $l as u32;
+            let x = (l & 0xFFFF) as int;
+            let y = (l >> 16) as int;
+            let flags = $w as u32;
+            $self_.on_left_button_up(x, y, flags);
+            return 0 as ::windows::ll::types::LRESULT;
+        }
+    );
+    ($self_:ident, $msg:ident, $w:ident, $l:ident, WM_KEYDOWN) => (
+        if $msg == 0x0100 { // WM_KEYDOWN
+            return $self_.on_key_down($w as u8, $l as u32) as ::windows::ll::types::LRESULT;
+        }
+    );
+    ($self_:ident, $msg:ident, $w:ident, $l:ident, WM_KEYUP) => (
+        if $msg == 0x0101 { // WM_KEYUP
+            return $self_.on_key_up($w as u8, $l as u32) as ::windows::ll::types::LRESULT;
+        }
+    );
+    ($self_:ident, $msg:ident, $w:ident, $l:ident, WM_ERASEBKGND) => (
+        if $msg == 0x0014 { // WM_ERASEBKGND
+            // Returning 1 means that the background no longer needs erasing.
+            return $self_.on_erase_background() as ::windows::ll::types::LRESULT;
+        }
+    );
+    ($self_:ident, $msg:ident, $w:ident, $l:ident, ANY) => (
+        if let Some(result) = $self_.on_message($msg, $w, $l) {
+            return result;
+        }
+    );
 );
 
 #[macro_export]


### PR DESCRIPTION
This adds some assorted message handers:
 - left mouse button up/down
 - keys up/down
 - on erase background
 - on message -- a fallthrough handler to handle custom messages
   or those this library doesn't cover.

and some drawing functions:
 - invalidate_rect
 - invalidate
 - set_text_color
 - set_background_color
 - fill_rect
 - rect.

Some more raw win32 drawing functions are also exposed.