### PR TITLE
Buildfix

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -129,13 +129,13 @@ impl MainFrame {
             return None;
         }
 
-        let wproc = box MainFrame {
+        let wproc = Box::new(MainFrame {
             win: Window::null(),
             title: title.clone(),
             text_height: text_height,
             edit: RefCell::new(None),
             font: RefCell::new(None),
-        };
+        });
 
         let win_params = WindowParams {
             window_name: title,

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -7,6 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unstable)]
 
 #[macro_use]
 extern crate log;

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -120,7 +120,7 @@ impl MainFrame {
             icon: icon,
             icon_small: None,
             cursor: Image::load_cursor_resource(32514), // hourglass
-            background: (5i + 1) as HBRUSH,
+            background: (5 + 1) as HBRUSH,
             menu: MenuResource::MenuId(MENU_MAIN),
             cls_extra: 0,
             wnd_extra: 0,

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -7,12 +7,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(globs, macro_rules, phase)]
 
-#[phase(plugin, link)]
+#[macro_use]
 extern crate log;
 
-#[phase(plugin, link)]
+#[macro_use]
 extern crate "rust-windows" as windows;
 
 use std::ptr;

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -31,15 +31,15 @@ use windows::font::Font;
 use windows::font;
 
 // TODO duplicate of hello.rc
-static IDI_ICON: int = 0x101;
-static MENU_MAIN: int = 0x201;
-//static MENU_NEW: int = 0x202;
-//static MENU_EXIT: int = 0x203;
+static IDI_ICON: isize = 0x101;
+static MENU_MAIN: isize = 0x201;
+//static MENU_NEW: isize = 0x202;
+//static MENU_EXIT: isize = 0x203;
 
 struct MainFrame {
     win: Window,
     title: String,
-    text_height: int,
+    text_height: isize,
     edit: RefCell<Option<Window>>,
     font: RefCell<Option<Font>>,
 }
@@ -55,8 +55,8 @@ impl OnCreate for MainFrame {
                 window::ES_AUTOVSCROLL | window::ES_MULTILINE | window::ES_NOHIDESEL,
             x: 0,
             y: self.text_height,
-            width: rect.right as int,
-            height: rect.bottom as int - self.text_height,
+            width: rect.right as isize,
+            height: rect.bottom as isize - self.text_height,
             parent: self.win,
             menu: ptr::null_mut(),
             ex_style: 0,
@@ -85,7 +85,7 @@ impl OnCreate for MainFrame {
 }
 
 impl OnSize for MainFrame {
-    fn on_size(&self, width: int, height: int) {
+    fn on_size(&self, width: isize, height: isize) {
         // SWP_NOOWNERZORDER | SWP_NOZORDER
         let h = self.text_height;
         self.edit.borrow().expect("edit is empty")
@@ -111,7 +111,7 @@ impl OnFocus for MainFrame {
 }
 
 impl MainFrame {
-    fn new(instance: Instance, title: String, text_height: int) -> Option<Window> {
+    fn new(instance: Instance, title: String, text_height: isize) -> Option<Window> {
         let icon = Image::load_resource(instance, IDI_ICON, ImageType::IMAGE_ICON, 0, 0);
         let wnd_class = WndClass {
             classname: "MainFrame".to_string(),
@@ -163,5 +163,5 @@ fn main() {
     main.update();
 
     let exit_code = main_window_loop();
-    std::os::set_exit_status(exit_code as int);
+    std::os::set_exit_status(exit_code as isize);
 }

--- a/font.rs
+++ b/font.rs
@@ -17,7 +17,7 @@ use ll::types::{DWORD, HFONT};
 use ll::gdi;
 use wchar::ToCU16Str;
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub enum CharSet {
     ANSI_CHARSET = 0,
     DEFAULT_CHARSET = 1,
@@ -41,7 +41,7 @@ pub enum CharSet {
     MAC_CHARSET = 77,
 }
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub enum OutputPrecision {
     OUT_DEFAULT_PRECIS = 0,
     OUT_STRING_PRECIS = 1,
@@ -55,7 +55,7 @@ pub enum OutputPrecision {
     OUT_PS_ONLY_PRECIS = 10,
 }
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub enum ClipPrecision {
     CLIP_DEFAULT_PRECIS = 0,
     CLIP_CHARACTER_PRECIS = 1,
@@ -69,7 +69,7 @@ pub enum ClipPrecision {
     // CLIP_DFA_OVERRIDE
 }
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub enum Quality {
     DEFAULT_QUALITY = 0,
     DRAFT_QUALITY = 1,
@@ -80,14 +80,14 @@ pub enum Quality {
     CLEARTYPE_QUALITY = 5,
 }
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub enum Pitch {
     DEFAULT_PITCH = 0,
     FIXED_PITCH = 1,
     VARIABLE_PITCH = 2,
 }
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub enum Family {
     FF_DECORATIVE = 80,
     FF_DONTCARE = 0,
@@ -137,7 +137,7 @@ impl Default for FontAttr {
     }
 }
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct Font {
     pub font: HFONT,
 }

--- a/font.rs
+++ b/font.rs
@@ -98,11 +98,11 @@ pub enum Family {
 }
 
 pub struct FontAttr {
-    pub height: int,
-    pub width: int,
-    pub escapement: int,
-    pub orientation: int,
-    pub weight: int,
+    pub height: isize,
+    pub width: isize,
+    pub escapement: isize,
+    pub orientation: isize,
+    pub weight: isize,
     pub italic: bool,
     pub underline: bool,
     pub strike_out: bool,

--- a/gdi.rs
+++ b/gdi.rs
@@ -16,7 +16,7 @@ use ll::gdi;
 use font::Font;
 use window::WindowImpl;
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct Dc {
     pub raw: HDC,
 }

--- a/gdi.rs
+++ b/gdi.rs
@@ -26,7 +26,7 @@ impl Dc {
         self.raw
     }
 
-    pub fn text_out(&self, x: int, y: int, s: &str) -> bool {
+    pub fn text_out(&self, x: isize, y: isize, s: &str) -> bool {
         let mut s16 : Vec<u16> = s.utf16_units().collect();
         let len = s16.len();
 
@@ -58,15 +58,15 @@ impl Dc {
         unsafe { gdi::SetBkColor(self.raw, color) }
     }
 
-    pub fn create_compatible_bitmap(&self, width: int, height: int) -> Bitmap {
+    pub fn create_compatible_bitmap(&self, width: isize, height: isize) -> Bitmap {
         let raw = unsafe {
             gdi::CreateCompatibleBitmap(self.raw, width as c_int, height as c_int)
         };
         Bitmap { raw: raw }
     }
 
-    pub fn bit_blt(&self, pos: (int, int), size: (int, int), src: &Dc,
-                   src_pos: (int, int), flag: DWORD) -> bool {
+    pub fn bit_blt(&self, pos: (isize, isize), size: (isize, isize), src: &Dc,
+                   src_pos: (isize, isize), flag: DWORD) -> bool {
         let res = unsafe {
             let (px, py) = pos;
             let (w, h) = size;
@@ -77,7 +77,7 @@ impl Dc {
         return res != 0;
     }
 
-    pub fn fill_rect(&self, left_top: (int, int), right_bottom: (int, int), brush: HBRUSH) -> bool {
+    pub fn fill_rect(&self, left_top: (isize, isize), right_bottom: (isize, isize), brush: HBRUSH) -> bool {
         let (left, top) = left_top;
         let (right, bottom) = right_bottom;
         let rect = RECT {
@@ -90,7 +90,7 @@ impl Dc {
         return res != 0;
     }
 
-    pub fn rect(&self, left_top: (int, int), right_bottom: (int, int)) -> bool {
+    pub fn rect(&self, left_top: (isize, isize), right_bottom: (isize, isize)) -> bool {
         let (left, top) = left_top;
         let (right, bottom) = right_bottom;
         let res = unsafe {

--- a/gdi.rs
+++ b/gdi.rs
@@ -118,7 +118,7 @@ impl PaintDc {
             },
             fRestore: 0 as BOOL,
             fIncUpdate: 0 as BOOL,
-            rgbReserved: [0 as BYTE, ..32],
+            rgbReserved: [0 as BYTE; 32],
         };
 
         let wnd = w.wnd().wnd;

--- a/instance.rs
+++ b/instance.rs
@@ -11,7 +11,7 @@ use std::ptr;
 
 use ll::types::HINSTANCE;
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct Instance {
     pub instance: HINSTANCE
 }

--- a/lib.rs
+++ b/lib.rs
@@ -24,7 +24,7 @@ use ll::types::{HWND, LPARAM, UINT, WPARAM, LRESULT, DWORD};
 
 pub mod ll;
 
-pub mod macros;
+#[macro_use] pub mod macros;
 pub mod instance;
 pub mod resource;
 pub mod font;

--- a/lib.rs
+++ b/lib.rs
@@ -7,12 +7,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(globs, phase, macro_rules)]
 #![crate_type = "lib"]
 #![crate_type = "dylib"]
 #![crate_name = "rust-windows"]
 
-#[phase(plugin, link)] extern crate log;
+#[macro_use] extern crate log;
 
 extern crate libc;
 extern crate collections;

--- a/lib.rs
+++ b/lib.rs
@@ -41,7 +41,7 @@ pub fn def_window_proc(hwnd: HWND, msg: UINT, w: WPARAM, l: LPARAM) -> LRESULT {
     unsafe { ll::all::DefWindowProcW(hwnd, msg, w, l) }
 }
 
-pub fn main_window_loop() -> uint {
+pub fn main_window_loop() -> usize {
     let msg = MSG {
         hwnd: ptr::null_mut(),
         message: 0 as UINT,
@@ -58,7 +58,7 @@ pub fn main_window_loop() -> uint {
 
         if ret == 0 {
             let exit_code = msg.wParam;
-            return exit_code as uint;
+            return exit_code as usize;
         }
         else {
             unsafe {

--- a/lib.rs
+++ b/lib.rs
@@ -7,6 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unstable)]
 #![crate_type = "lib"]
 #![crate_type = "dylib"]
 #![crate_name = "rust-windows"]

--- a/ll/all.rs
+++ b/ll/all.rs
@@ -114,7 +114,7 @@ pub struct PAINTSTRUCT {
     pub rcPaint: RECT,
     pub fRestore: BOOL,
     pub fIncUpdate: BOOL,
-    pub rgbReserved: [BYTE, ..32],
+    pub rgbReserved: [BYTE; 32],
 }
 
 // kernel32

--- a/ll/all.rs
+++ b/ll/all.rs
@@ -15,7 +15,7 @@ use ll::types::*;
 pub type WNDPROC = *const c_void;
 
 #[repr(C)]
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct SECURITY_ATTRIBUTES {
     pub nLength: DWORD,
     pub lpSecurityDescriptor: LPVOID,
@@ -23,7 +23,7 @@ pub struct SECURITY_ATTRIBUTES {
 }
 
 #[repr(C)]
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct PROCESS_INFORMATION {
     pub hProcess: HANDLE,
     pub hThread: HANDLE,
@@ -32,7 +32,7 @@ pub struct PROCESS_INFORMATION {
 }
 
 #[repr(C)]
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct STARTUPINFO {
     pub cb: DWORD,
     pub lpReserved: LPWSTR,
@@ -55,7 +55,7 @@ pub struct STARTUPINFO {
 }
 
 #[repr(C)]
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct WNDCLASSEX {
     pub cbSize: UINT,
     pub style: UINT,
@@ -72,7 +72,7 @@ pub struct WNDCLASSEX {
 }
 
 #[repr(C)]
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct CREATESTRUCT {
     pub lpCreateParams: LPVOID,
     pub hInstance: HINSTANCE,
@@ -89,14 +89,14 @@ pub struct CREATESTRUCT {
 }
 
 #[repr(C)]
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct POINT {
     pub x: LONG,
     pub y: LONG,
 }
 
 #[repr(C)]
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct MSG {
     pub hwnd: HWND,
     pub message: UINT,
@@ -106,7 +106,7 @@ pub struct MSG {
     pub pt: POINT,
 }
 
-#[deriving(Copy)]
+#[derive(Copy)]
 #[repr(C)]
 pub struct PAINTSTRUCT {
     pub hdc: HDC,

--- a/ll/types.rs
+++ b/ll/types.rs
@@ -219,7 +219,7 @@ pub type SC_LOCK = LPVOID;
 pub type SERVICE_STATUS_HANDLE = HANDLE;
 
 // winternl.h
-#[deriving(Copy)]
+#[derive(Copy)]
 #[repr(C)]
 pub struct UNICODE_STRING {
     pub Length: USHORT,
@@ -234,7 +234,7 @@ pub type QWORD = u64; // unsigned __int64
 
 // additional types used in common now
 
-#[deriving(Copy)]
+#[derive(Copy)]
 #[repr(C)]
 pub struct RECT {
     pub left: LONG,

--- a/macros.rs
+++ b/macros.rs
@@ -35,8 +35,8 @@ macro_rules! wnd_proc_thunk(
     ($self_:ident, $msg:ident, $w:ident, $l:ident, WM_SIZE) => (
         if $msg == 0x0005 { // WM_SIZE
             let l = $l as u32;
-            let width = (l & 0xFFFF) as int;
-            let height = (l >> 16) as int;
+            let width = (l & 0xFFFF) as isize;
+            let height = (l >> 16) as isize;
             $self_.on_size(width, height);
             return 0 as ::windows::ll::types::LRESULT;
         }
@@ -57,8 +57,8 @@ macro_rules! wnd_proc_thunk(
     ($self_:ident, $msg:ident, $w:ident, $l:ident, WM_LBUTTONDOWN) => (
         if $msg == 0x0201 { // WM_LBUTTONDOWN
             let l = $l as u32;
-            let x = (l & 0xFFFF) as int;
-            let y = (l >> 16) as int;
+            let x = (l & 0xFFFF) as isize;
+            let y = (l >> 16) as isize;
             let flags = $w as u32;
             $self_.on_left_button_down(x, y, flags);
             return 0 as ::windows::ll::types::LRESULT;
@@ -67,8 +67,8 @@ macro_rules! wnd_proc_thunk(
     ($self_:ident, $msg:ident, $w:ident, $l:ident, WM_LBUTTONUP) => (
         if $msg == 0x0202 { // WM_LBUTTONUP
             let l = $l as u32;
-            let x = (l & 0xFFFF) as int;
-            let y = (l >> 16) as int;
+            let x = (l & 0xFFFF) as isize;
+            let y = (l >> 16) as isize;
             let flags = $w as u32;
             $self_.on_left_button_up(x, y, flags);
             return 0 as ::windows::ll::types::LRESULT;

--- a/macros.rs
+++ b/macros.rs
@@ -7,8 +7,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![macro_escape]
-
 #[macro_export]
 macro_rules! wnd_proc_thunk(
     ($self_:ident, $msg:ident, $w:ident, $l:ident, WM_CREATE) => (

--- a/resource.rs
+++ b/resource.rs
@@ -77,7 +77,8 @@ pub enum MenuResource {
 }
 
 impl MenuResource {
-    pub fn with_menu_p<T>(&self, f: |*const u16| -> T) -> T {
+    pub fn with_menu_p<T, F>(&self, f: F) -> T 
+        where F: FnOnce(*const u16) -> T {
         match *self {
             MenuResource::MenuName(ref s) => {
                 let u = s.as_slice().to_c_u16();

--- a/resource.rs
+++ b/resource.rs
@@ -31,14 +31,14 @@ impl<T: ToHandle> ToHandle for Option<T> {
 }
 
 #[allow(non_camel_case_types)]
-#[deriving(Copy)]
+#[derive(Copy)]
 pub enum ImageType {
     IMAGE_BITMAP = 0,
     IMAGE_ICON = 1,
     IMAGE_CURSOR = 2,
 }
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct Image {
     pub image: HANDLE,
 }

--- a/resource.rs
+++ b/resource.rs
@@ -44,7 +44,7 @@ pub struct Image {
 }
 
 impl Image {
-    pub fn load_resource(instance: Instance, id: int, img_type: ImageType, width: int, height: int) -> Option<Image> {
+    pub fn load_resource(instance: Instance, id: isize, img_type: ImageType, width: isize, height: isize) -> Option<Image> {
         let img = unsafe {
             super::ll::all::LoadImageW(
                 instance.instance, std::mem::transmute(id), img_type as UINT,
@@ -59,7 +59,7 @@ impl Image {
         }
     }
 
-    pub fn load_cursor_resource(id: int) -> Option<Image> {
+    pub fn load_cursor_resource(id: isize) -> Option<Image> {
         let null_instance = Instance { instance: ptr::null_mut() };
         Image::load_resource(null_instance, id, ImageType::IMAGE_CURSOR, 0, 0)
     }
@@ -73,7 +73,7 @@ impl ToHandle for Image {
 
 pub enum MenuResource {
     MenuName(String),
-    MenuId(int),
+    MenuId(isize),
 }
 
 impl MenuResource {

--- a/wchar.rs
+++ b/wchar.rs
@@ -66,7 +66,8 @@ impl fmt::Show for CU16String {
 
 /// Parses a C utf-16 "multistring".
 /// See `std::c_str::from_c_multistring` for detailed explanation.
-pub unsafe fn from_c_u16_multistring(buf: *const u16, count: Option<uint>, f: |&[u16]|) -> uint {
+pub unsafe fn from_c_u16_multistring<F>(buf: *const u16, count: Option<uint>, f: F) -> uint 
+    where F: Fn(&[u16]) {
     let mut curr_ptr: uint = buf as uint;
     let mut ctr = 0;
     let (limited_count, limit) = match count {

--- a/wchar.rs
+++ b/wchar.rs
@@ -16,7 +16,7 @@ use std::vec::Vec;
 pub struct CU16String {
     buf: *const u16,
     /// length of buffer, including null
-    len: uint,
+    len: usize,
 }
 
 impl CU16String {
@@ -32,7 +32,7 @@ impl CU16String {
                     }
                     length_counter += 1;
                 }
-                length_counter as uint
+                length_counter as usize
             }
         }
     }
@@ -66,9 +66,9 @@ impl fmt::Show for CU16String {
 
 /// Parses a C utf-16 "multistring".
 /// See `std::c_str::from_c_multistring` for detailed explanation.
-pub unsafe fn from_c_u16_multistring<F>(buf: *const u16, count: Option<uint>, f: F) -> uint 
+pub unsafe fn from_c_u16_multistring<F>(buf: *const u16, count: Option<usize>, f: F) -> usize 
     where F: Fn(&[u16]) {
-    let mut curr_ptr: uint = buf as uint;
+    let mut curr_ptr: usize = buf as usize;
     let mut ctr = 0;
     let (limited_count, limit) = match count {
         Some(limit) => (true, limit),

--- a/window.rs
+++ b/window.rs
@@ -24,14 +24,14 @@ use resource::*;
 
 pub struct WndClass {
     pub classname: String,
-    pub style: uint,
+    pub style: usize,
     pub icon: Option<Image>,
     pub icon_small: Option<Image>,
     pub cursor: Option<Image>,
     pub background: HBRUSH,
     pub menu: MenuResource,
-    pub cls_extra: int,
-    pub wnd_extra: int,
+    pub cls_extra: isize,
+    pub wnd_extra: isize,
 }
 
 impl WndClass {
@@ -105,10 +105,10 @@ pub static ES_WANTRETURN: u32 = 4096;
 pub struct WindowParams {
     pub window_name: String,
     pub style: u32,
-    pub x: int,
-    pub y: int,
-    pub width: int,
-    pub height: int,
+    pub x: isize,
+    pub y: isize,
+    pub width: isize,
+    pub height: isize,
     pub parent: Window,
     pub menu: HMENU,
     pub ex_style: u32,
@@ -163,11 +163,11 @@ impl Window {
         }
     }
 
-    pub fn show(&self, cmd_show: int) -> bool {
+    pub fn show(&self, cmd_show: isize) -> bool {
         unsafe { super::ll::all::ShowWindow(self.wnd, cmd_show as c_int) == 0 }
     }
 
-    pub fn show_async(&self, cmd_show: int) -> bool {
+    pub fn show_async(&self, cmd_show: isize) -> bool {
         unsafe { super::ll::all::ShowWindowAsync(self.wnd, cmd_show as c_int) == 0 }
     }
 
@@ -192,7 +192,7 @@ impl Window {
     }
 
     pub fn set_window_pos(
-        &self, x: int, y: int, width: int, height: int, flags: UINT
+        &self, x: isize, y: isize, width: isize, height: isize, flags: UINT
     ) -> bool {
         // TODO: hwndInsertAfter
         unsafe {
@@ -308,7 +308,7 @@ pub trait OnPaint {
 }
 
 pub trait OnSize {
-    fn on_size(&self, _width: int, _height: int) {
+    fn on_size(&self, _width: isize, _height: isize) {
     }
 }
 
@@ -318,12 +318,12 @@ pub trait OnFocus {
 }
 
 pub trait OnLeftButtonDown {
-    fn on_left_button_down(&self, _x: int, _y: int, _flags: u32) {
+    fn on_left_button_down(&self, _x: isize, _y: isize, _flags: u32) {
     }
 }
 
 pub trait OnLeftButtonUp {
-    fn on_left_button_up(&self, _x: int, _y: int, _flags: u32) {
+    fn on_left_button_up(&self, _x: isize, _y: isize, _flags: u32) {
     }
 }
 

--- a/window.rs
+++ b/window.rs
@@ -114,7 +114,7 @@ pub struct WindowParams {
     pub ex_style: u32,
 }
 
-#[deriving(PartialEq, Eq, Hash, Copy)]
+#[derive(PartialEq, Eq, Hash, Copy)]
 pub struct Window {
     pub wnd: HWND,
 }


### PR DESCRIPTION
Build Fix for rust-windows

list of changes:
- change array repeat syntax ( [ x, ..n]  tp [x;n] )
- #[deriving()] to #[derive()]
- replace uint & int type to usize and isize
- use Box::new instead of box expression
- use unboxed closure
- remove #[macro_escape]

$ rustc --version
rustc 1.0.0-nightly (170c4399e 2015-01-14 00:41:55 +0000)