### PR TITLE
Buildfix for recent winapi changes

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3,9 +3,45 @@ name = "examples"
 version = "0.0.1"
 dependencies = [
  "rust-windows 0.0.1",
+ "winapi 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gdi32-sys"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rust-windows"
 version = "0.0.1"
+dependencies = [
+ "gdi32-sys 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "user32-sys 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "user32-sys"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -16,3 +16,6 @@ path = "src/hello.rs"
 
 [dependencies.rust-windows]
 path = ".."
+
+[dependencies]
+winapi = "*"

--- a/examples/src/hello.rs
+++ b/examples/src/hello.rs
@@ -12,6 +12,8 @@
 #[macro_use]
 extern crate log;
 
+extern crate winapi;
+
 #[macro_use]
 extern crate "rust-windows" as windows;
 
@@ -19,9 +21,9 @@ use std::ptr;
 use std::cell::RefCell;
 use std::default::Default;
 
+use winapi::{UINT, HBRUSH, CREATESTRUCTW};
+
 use windows::main_window_loop;
-use windows::ll::types::{UINT, HBRUSH};
-use windows::ll::all::CREATESTRUCT;
 use windows::instance::Instance;
 use windows::resource::*;
 use windows::window::{WindowImpl, Window, WndClass, WindowParams};
@@ -48,7 +50,7 @@ struct MainFrame {
 wnd_proc!(MainFrame, win, WM_CREATE, WM_DESTROY, WM_SIZE, WM_SETFOCUS, WM_PAINT);
 
 impl OnCreate for MainFrame {
-    fn on_create(&self, _cs: &CREATESTRUCT) -> bool {
+    fn on_create(&self, _cs: &CREATESTRUCTW) -> bool {
         let rect = self.win.client_rect().unwrap();
         let params = WindowParams {
             window_name: "Hello World".to_string(),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -12,22 +12,22 @@ macro_rules! wnd_proc_thunk(
     ($self_:ident, $msg:ident, $w:ident, $l:ident, WM_CREATE) => (
         if $msg == 0x0001 { // WM_CREATE
             let cs = unsafe {
-                let pcs = ::std::mem::transmute::<::windows::ll::types::LPARAM,
-                                                   *const ::windows::ll::all::CREATESTRUCT>($l);
+                let pcs = ::std::mem::transmute::<::winapi::LPARAM,
+                                                   *const ::winapi::CREATESTRUCTW>($l);
                 &(*pcs)
             };
             let ret = $self_.on_create(cs);
             if ret {
-                return 0 as ::windows::ll::types::LRESULT;
+                return 0 as ::winapi::LRESULT;
             } else {
-                return -1 as ::windows::ll::types::LRESULT;
+                return -1 as ::winapi::LRESULT;
             }
         }
     );
     ($self_:ident, $msg:ident, $w:ident, $l:ident, WM_DESTROY) => (
         if $msg == 0x0002 { // WM_DESTROY
             $self_.on_destroy();
-            return 0 as ::windows::ll::types::LRESULT;
+            return 0 as ::winapi::LRESULT;
         }
     );
     ($self_:ident, $msg:ident, $w:ident, $l:ident, WM_SIZE) => (
@@ -36,20 +36,20 @@ macro_rules! wnd_proc_thunk(
             let width = (l & 0xFFFF) as isize;
             let height = (l >> 16) as isize;
             $self_.on_size(width, height);
-            return 0 as ::windows::ll::types::LRESULT;
+            return 0 as ::winapi::LRESULT;
         }
     );
     ($self_:ident, $msg:ident, $w:ident, $l:ident, WM_SETFOCUS) => (
         if $msg == 0x0007 { // WM_SETFOCUS
-            let w = ::windows::window::Window { wnd: $w as ::windows::ll::types::HWND };
+            let w = ::windows::window::Window { wnd: $w as ::winapi::HWND };
             $self_.on_focus(w);
-            return 0 as ::windows::ll::types::LRESULT;
+            return 0 as ::winapi::LRESULT;
         }
     );
     ($self_:ident, $msg:ident, $w:ident, $l:ident, WM_PAINT) => (
         if $msg == 0x000F { // WM_PAINT
             $self_.on_paint();
-            return 0 as ::windows::ll::types::LRESULT;
+            return 0 as ::winapi::LRESULT;
         }
     );
     ($self_:ident, $msg:ident, $w:ident, $l:ident, WM_LBUTTONDOWN) => (
@@ -59,7 +59,7 @@ macro_rules! wnd_proc_thunk(
             let y = (l >> 16) as isize;
             let flags = $w as u32;
             $self_.on_left_button_down(x, y, flags);
-            return 0 as ::windows::ll::types::LRESULT;
+            return 0 as ::winapi::LRESULT;
         }
     );
     ($self_:ident, $msg:ident, $w:ident, $l:ident, WM_LBUTTONUP) => (
@@ -69,23 +69,23 @@ macro_rules! wnd_proc_thunk(
             let y = (l >> 16) as isize;
             let flags = $w as u32;
             $self_.on_left_button_up(x, y, flags);
-            return 0 as ::windows::ll::types::LRESULT;
+            return 0 as ::winapi::LRESULT;
         }
     );
     ($self_:ident, $msg:ident, $w:ident, $l:ident, WM_KEYDOWN) => (
         if $msg == 0x0100 { // WM_KEYDOWN
-            return $self_.on_key_down($w as u8, $l as u32) as ::windows::ll::types::LRESULT;
+            return $self_.on_key_down($w as u8, $l as u32) as ::winapi::::winapi::LRESULT;
         }
     );
     ($self_:ident, $msg:ident, $w:ident, $l:ident, WM_KEYUP) => (
         if $msg == 0x0101 { // WM_KEYUP
-            return $self_.on_key_up($w as u8, $l as u32) as ::windows::ll::types::LRESULT;
+            return $self_.on_key_up($w as u8, $l as u32) as ::winapi::LRESULT;
         }
     );
     ($self_:ident, $msg:ident, $w:ident, $l:ident, WM_ERASEBKGND) => (
         if $msg == 0x0014 { // WM_ERASEBKGND
             // Returning 1 means that the background no longer needs erasing.
-            return $self_.on_erase_background() as ::windows::ll::types::LRESULT;
+            return $self_.on_erase_background() as ::winapi::LRESULT;
         }
     );
     ($self_:ident, $msg:ident, $w:ident, $l:ident, ANY) => (
@@ -108,8 +108,8 @@ macro_rules! wnd_proc(
             &mut self.$win
         }
 
-        fn wnd_proc(&self, msg: ::windows::ll::types::UINT, w: ::windows::ll::types::WPARAM,
-                    l: ::windows::ll::types::LPARAM) -> ::windows::ll::types::LRESULT {
+        fn wnd_proc(&self, msg: ::winapi::UINT, w: ::winapi::WPARAM,
+                    l: ::winapi::LPARAM) -> ::winapi::LRESULT {
             $(
                 wnd_proc_thunk!(self, msg, w, l, $msg);
             )+


### PR DESCRIPTION
The example fail to build because hello.rs & macros.rs still use window::ll module instead new winapi ones.