### PR TITLE
Work on rust 1.0.0 beta.4, fix tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["klutzy <https://github.com/klutzy>",
 tags = []
 
 [lib]
-name = "rust-windows"
+name = "rust_windows"
 
 [dependencies]
 gdi32-sys = "*"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2,61 +2,64 @@
 name = "examples"
 version = "0.0.1"
 dependencies = [
- "log 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-windows 0.0.1",
- "winapi 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gdi32-sys"
-version = "0.0.4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "kernel32-sys"
-version = "0.0.11"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libc"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
-version = "0.2.5"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rust-windows"
 version = "0.0.1"
 dependencies = [
- "gdi32-sys 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "user32-sys 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gdi32-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "user32-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "user32-sys"
-version = "0.0.11"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "winapi"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/examples/src/hello.rs
+++ b/examples/src/hello.rs
@@ -15,7 +15,7 @@ extern crate log;
 extern crate winapi;
 
 #[macro_use]
-extern crate "rust-windows" as windows;
+extern crate rust_windows as windows;
 
 use std::ptr;
 use std::cell::RefCell;

--- a/src/font.rs
+++ b/src/font.rs
@@ -17,7 +17,7 @@ use winapi::{DWORD, HFONT, c_int};
 
 use wchar::ToCU16Str;
 
-#[derive(Copy)]
+#[derive(Clone,Copy)]
 pub enum CharSet {
     ANSI_CHARSET = 0,
     DEFAULT_CHARSET = 1,
@@ -41,7 +41,7 @@ pub enum CharSet {
     MAC_CHARSET = 77,
 }
 
-#[derive(Copy)]
+#[derive(Clone,Copy)]
 pub enum OutputPrecision {
     OUT_DEFAULT_PRECIS = 0,
     OUT_STRING_PRECIS = 1,
@@ -55,7 +55,7 @@ pub enum OutputPrecision {
     OUT_PS_ONLY_PRECIS = 10,
 }
 
-#[derive(Copy)]
+#[derive(Clone,Copy)]
 pub enum ClipPrecision {
     CLIP_DEFAULT_PRECIS = 0,
     CLIP_CHARACTER_PRECIS = 1,
@@ -69,7 +69,7 @@ pub enum ClipPrecision {
     // CLIP_DFA_OVERRIDE
 }
 
-#[derive(Copy)]
+#[derive(Clone,Copy)]
 pub enum Quality {
     DEFAULT_QUALITY = 0,
     DRAFT_QUALITY = 1,
@@ -80,14 +80,14 @@ pub enum Quality {
     CLEARTYPE_QUALITY = 5,
 }
 
-#[derive(Copy)]
+#[derive(Clone,Copy)]
 pub enum Pitch {
     DEFAULT_PITCH = 0,
     FIXED_PITCH = 1,
     VARIABLE_PITCH = 2,
 }
 
-#[derive(Copy)]
+#[derive(Clone,Copy)]
 pub enum Family {
     FF_DECORATIVE = 80,
     FF_DONTCARE = 0,

--- a/src/gdi.rs
+++ b/src/gdi.rs
@@ -19,7 +19,7 @@ use winapi::{
 use font::Font;
 use window::WindowImpl;
 
-#[derive(Copy)]
+#[derive(Clone,Copy)]
 pub struct Dc {
     pub raw: HDC,
 }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -12,7 +12,7 @@ use std::ptr;
 use kernel32;
 use winapi::{HINSTANCE};
 
-#[derive(Copy)]
+#[derive(Clone,Copy)]
 pub struct Instance {
     pub instance: HINSTANCE
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,16 +9,16 @@
 
 #![crate_type = "lib"]
 #![crate_type = "dylib"]
-#![crate_name = "rust-windows"]
+#![crate_name = "rust_windows"]
 
 #![feature(collections, core)]
 
 #[macro_use]
 extern crate log;
 extern crate collections;
-extern crate "gdi32-sys" as gdi32;
-extern crate "kernel32-sys" as kernel32;
-extern crate "user32-sys" as user32;
+extern crate gdi32;
+extern crate kernel32;
+extern crate user32;
 extern crate winapi;
 
 use std::ptr;

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -30,14 +30,14 @@ impl<T: ToHandle> ToHandle for Option<T> {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Copy)]
+#[derive(Clone,Copy)]
 pub enum ImageType {
     IMAGE_BITMAP = 0,
     IMAGE_ICON = 1,
     IMAGE_CURSOR = 2,
 }
 
-#[derive(Copy)]
+#[derive(Clone,Copy)]
 pub struct Image {
     pub image: HANDLE,
 }
@@ -76,7 +76,7 @@ pub enum MenuResource {
 }
 
 impl MenuResource {
-    pub fn with_menu_p<T, F>(&self, f: F) -> T 
+    pub fn with_menu_p<T, F>(&self, f: F) -> T
         where F: FnOnce(*const u16) -> T {
         match *self {
             MenuResource::MenuName(ref s) => {

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -80,7 +80,7 @@ impl MenuResource {
         where F: FnOnce(*const u16) -> T {
         match *self {
             MenuResource::MenuName(ref s) => {
-                let u = s.as_slice().to_c_u16();
+                let u = &s.to_c_u16();
                 f(u.as_ptr())
             }
             MenuResource::MenuId(id) => unsafe { f(std::mem::transmute(id)) },

--- a/src/wchar.rs
+++ b/src/wchar.rs
@@ -33,7 +33,7 @@ impl CU16String {
                     }
                     length_counter += 1;
                 }
-		length_counter += 1;
+                length_counter += 1;
                 length_counter as usize
             }
         }
@@ -151,7 +151,6 @@ mod test {
         unsafe {
             from_c_u16_multistring(buf, None, |p| {
                 let b = String::from_utf16(p).unwrap();
-		println!("{:?}", p);
                 assert_eq!(b, compare[i].to_owned());
                 assert_eq!(b.chars().count(), i + 1);
                 i += 1;


### PR DESCRIPTION
There was a broken assumption on CU16String that len would contain buffer length including null byte which broke all the tests. This is fixed. 

The rest is pretty much changing the as_slice methods to use borrow + range operators, as necessary + gentoo's fixes from another PR. 